### PR TITLE
Take $GALA fee into account when determining what to swap

### DIFF
--- a/src/strategies/basic_swap_accepter/get_swap_to_accept.ts
+++ b/src/strategies/basic_swap_accepter/get_swap_to_accept.ts
@@ -35,7 +35,7 @@ function calculateUsesToAccept(swap: IRawSwap, maxGive: string) {
 }
 
 export async function getSwapsToAccept(
-  _reporter: IStatusReporter,
+  reporter: IStatusReporter,
   ownWalletAddress: string,
   pairLimits: readonly Readonly<IAccepterPairConfig>[],
   ownBalances: readonly Readonly<ITokenBalance>[],
@@ -56,6 +56,16 @@ export async function getSwapsToAccept(
   } = {},
 ): Promise<readonly Readonly<ISwapToAccept>[]> {
   const useableBalances = getUseableBalances(ownBalances);
+  const useableGala = useableBalances.find((b) => b.collection === 'GALA')?.quantity ?? '0';
+
+  if (BigNumber(useableGala).lt(1)) {
+    await reporter.sendAlert(
+      'I have no $GALA! I need at least 1 $GALA in order to pay the fee when accepting a swap.',
+    );
+
+    return [];
+  }
+
   const now = options.now ?? new Date();
   const nowMs = now.getTime();
 

--- a/src/strategies/basic_swap_creator/basic_swap_creator_strategy.ts
+++ b/src/strategies/basic_swap_creator/basic_swap_creator_strategy.ts
@@ -30,7 +30,7 @@ export class BasicSwapCreatorStrategy implements ISwapStrategy {
 
   async doTick(
     logger: ILogger,
-    _reporter: IStatusReporter,
+    reporter: IStatusReporter,
     _selfUserId: string,
     _galaSwapApi: IGalaSwapApi,
     createdSwapStore: MongoCreatedSwapStore,
@@ -58,6 +58,7 @@ export class BasicSwapCreatorStrategy implements ISwapStrategy {
     );
 
     const swapsToCreate = await getSwapsToCreate(
+      reporter,
       logger,
       ownBalances,
       ownSwaps,

--- a/src/strategies/basic_swap_creator/get_swap_to_create.ts
+++ b/src/strategies/basic_swap_creator/get_swap_to_create.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { IGalaSwapToken, IRawSwap, ITokenBalance } from '../../dependencies/galaswap/types.js';
+import { IStatusReporter } from '../../dependencies/status_reporters.js';
 import { areSameTokenClass, stringifyTokenClass } from '../../types/type_helpers.js';
 import { ILogger, ITokenClassKey } from '../../types/types.js';
 import { galaChainObjectIsExpired, getUseableBalances } from '../../utils/galachain_utils.js';
@@ -9,6 +10,7 @@ import { calculateSwapQuantitiesAndUses } from '../../utils/swap_uses.js';
 import { ISwapCreatorConfig } from './types.js';
 
 export async function getSwapsToCreate(
+  reporter: IStatusReporter,
   logger: ILogger,
   ownBalances: readonly Readonly<ITokenBalance>[],
   allSwaps: readonly Readonly<IRawSwap>[],
@@ -28,8 +30,17 @@ export async function getSwapsToCreate(
     now?: Date;
   },
 ) {
-  const useableBalances = getUseableBalances(ownBalances);
   const nowMs = options?.now?.getTime() ?? Date.now();
+  const useableBalances = getUseableBalances(ownBalances);
+  const useableGala = useableBalances.find((b) => b.collection === 'GALA')?.quantity ?? '0';
+
+  if (BigNumber(useableGala).lt(1)) {
+    await reporter.sendAlert(
+      'I have no $GALA! I need at least 1 $GALA in order to pay the fee when accepting a swap.',
+    );
+
+    return [];
+  }
 
   for (const target of config.targetActiveSwaps) {
     const givingBalanceForThisTarget =

--- a/src/strategies/basic_swap_creator/get_swap_to_create.ts
+++ b/src/strategies/basic_swap_creator/get_swap_to_create.ts
@@ -31,8 +31,9 @@ export async function getSwapsToCreate(
   },
 ) {
   const nowMs = options?.now?.getTime() ?? Date.now();
-  const useableBalances = getUseableBalances(ownBalances);
-  const useableGala = useableBalances.find((b) => b.collection === 'GALA')?.quantity ?? '0';
+
+  const useableBalancesPreFee = getUseableBalances(ownBalances);
+  const useableGala = useableBalancesPreFee.find((b) => b.collection === 'GALA')?.quantity ?? '0';
 
   if (BigNumber(useableGala).lt(1)) {
     await reporter.sendAlert(
@@ -41,6 +42,11 @@ export async function getSwapsToCreate(
 
     return [];
   }
+
+  const useableBalances = useableBalancesPreFee.map((b) => ({
+    ...b,
+    quantity: b.collection === 'GALA' ? BigNumber(b.quantity).minus(1).toString() : b.quantity,
+  }));
 
   for (const target of config.targetActiveSwaps) {
     const givingBalanceForThisTarget =

--- a/test/mocks/noop_proxy.ts
+++ b/test/mocks/noop_proxy.ts
@@ -1,3 +1,4 @@
+import { IStatusReporter } from '../../src/dependencies/status_reporters.js';
 import { ILogger } from '../../src/types/types.js';
 
 export const noopProxy = new Proxy(
@@ -10,3 +11,4 @@ export const noopProxy = new Proxy(
 );
 
 export const mockLogger: ILogger = noopProxy as ILogger;
+export const mockReporter: IStatusReporter = noopProxy as IStatusReporter;

--- a/test/strategy_tests/basic_swap_creator_stateless.spec.ts
+++ b/test/strategy_tests/basic_swap_creator_stateless.spec.ts
@@ -4,7 +4,7 @@ import { IRawSwap } from '../../src/dependencies/galaswap/types.js';
 import { getSwapsToCreate } from '../../src/strategies/basic_swap_creator/get_swap_to_create.js';
 import { mainLoopTick } from '../../src/tick_loop.js';
 import { MockGalaSwapApi } from '../mocks/mock_gala_swap_api.js';
-import { mockLogger, noopProxy } from '../mocks/noop_proxy.js';
+import { mockLogger, mockReporter, noopProxy } from '../mocks/noop_proxy.js';
 import {
   makeBalance,
   makeTargetActiveSwap,
@@ -35,7 +35,10 @@ describe('Basic swap creator tests', () => {
       }),
     ];
 
-    const ownBalances = [makeBalance({ collection: 'GUSDC', quantity: '1000' })];
+    const ownBalances = [
+      makeBalance({ collection: 'GUSDC', quantity: '1000' }),
+      makeBalance({ collection: 'GALA', quantity: '1' }),
+    ];
 
     const tokenValues = [
       makeTokenValue({ collection: 'GALA', usd: 0.05 }),
@@ -43,6 +46,7 @@ describe('Basic swap creator tests', () => {
     ];
 
     const swapsToCreate1 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
       ownBalances,
       createdSwaps,
@@ -84,8 +88,12 @@ describe('Basic swap creator tests', () => {
     ];
 
     const swapToCreate1 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
-      [makeBalance({ collection: 'GUSDC', quantity: '149' })],
+      [
+        makeBalance({ collection: 'GUSDC', quantity: '149' }),
+        makeBalance({ collection: 'GALA', quantity: '1' }),
+      ],
       createdSwaps,
       tokenValues,
       {
@@ -99,8 +107,12 @@ describe('Basic swap creator tests', () => {
     assert.equal(swapToCreate1.length, 0);
 
     const swapToCreate2 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
-      [makeBalance({ collection: 'GUSDC', quantity: '150' })],
+      [
+        makeBalance({ collection: 'GUSDC', quantity: '150' }),
+        makeBalance({ collection: 'GALA', quantity: '1' }),
+      ],
       createdSwaps,
       tokenValues,
       defaultTestSwapCreatorConfig,
@@ -130,6 +142,7 @@ describe('Basic swap creator tests', () => {
     ];
 
     const swapToCreate1 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
       [
         makeBalance({
@@ -140,6 +153,7 @@ describe('Basic swap creator tests', () => {
             { quantity: '1', expires: 0 },
           ],
         }),
+        makeBalance({ collection: 'GALA', quantity: '1' }),
       ],
       createdSwaps,
       tokenValues,
@@ -154,6 +168,7 @@ describe('Basic swap creator tests', () => {
     assert.equal(swapToCreate1.length, 0);
 
     const swapToCreate2 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
       [
         makeBalance({
@@ -161,6 +176,7 @@ describe('Basic swap creator tests', () => {
           quantity: '152',
           lockedHolds: [{ quantity: '2', expires: 0 }],
         }),
+        makeBalance({ collection: 'GALA', quantity: '1' }),
       ],
       createdSwaps,
       tokenValues,
@@ -185,7 +201,10 @@ describe('Basic swap creator tests', () => {
       }),
     ];
 
-    const ownBalances = [makeBalance({ collection: 'GUSDC', quantity: '1000' })];
+    const ownBalances = [
+      makeBalance({ collection: 'GUSDC', quantity: '1000' }),
+      makeBalance({ collection: 'GALA', quantity: '1' }),
+    ];
 
     const tokenValues = [
       makeTokenValue({ collection: 'GALA', usd: 0.05 }),
@@ -193,6 +212,7 @@ describe('Basic swap creator tests', () => {
     ];
 
     const swapTosCreate1 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
       ownBalances,
       createdSwaps,
@@ -258,7 +278,10 @@ describe('Basic swap creator tests', () => {
       }),
     ];
 
-    const ownBalances = [makeBalance({ collection: 'GUSDC', quantity: '1000' })];
+    const ownBalances = [
+      makeBalance({ collection: 'GUSDC', quantity: '1000' }),
+      makeBalance({ collection: 'GALA', quantity: '1' }),
+    ];
 
     const tokenValues = [
       makeTokenValue({ collection: 'GALA', usd: 0.05 }),
@@ -266,6 +289,7 @@ describe('Basic swap creator tests', () => {
     ];
 
     const swapTosCreate1 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
       ownBalances,
       createdSwaps,
@@ -281,6 +305,7 @@ describe('Basic swap creator tests', () => {
     assert.equal(swapTosCreate1.length, 1);
 
     const swapTosCreate2 = await getSwapsToCreate(
+      mockReporter,
       mockLogger,
       ownBalances,
       createdSwaps,

--- a/test/strategy_tests/basic_swap_creator_ticks.spec.ts
+++ b/test/strategy_tests/basic_swap_creator_ticks.spec.ts
@@ -24,7 +24,10 @@ describe('Basic swap creator tick tests', async () => {
       }),
     ];
 
-    const balances = [makeBalance({ collection: 'GUSDC', quantity: '1000' })];
+    const balances = [
+      makeBalance({ collection: 'GUSDC', quantity: '1000' }),
+      makeBalance({ collection: 'GALA', quantity: '1' }),
+    ];
 
     await tickTestRunner(
       new BasicSwapCreatorStrategy({
@@ -95,7 +98,10 @@ describe('Basic swap creator tick tests', async () => {
       },
     ];
 
-    const balances = [makeBalance({ collection: 'GUSDC', quantity: '1000' })];
+    const balances = [
+      makeBalance({ collection: 'GUSDC', quantity: '1000' }),
+      makeBalance({ collection: 'GALA', quantity: '1' }),
+    ];
 
     await tickTestRunner(
       new BasicSwapCreatorStrategy({


### PR DESCRIPTION
The bot was not taking the 1 $GALA fee into account when deciding whether to swap, and how much to swap. For example if the bot had 10 $GALA, it might try to accept a swap where it gives 10 $GALA. However, since there's a 1 $GALA fee, it can only actually give 9 $GALA. This change fixes that.