### PR TITLE
Add minimum balance maintenance feature to swap accepter config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "name": "Debug Bot",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["start"],
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "internalConsoleOptions": "neverOpen",
       "runtimeVersion": "20"
     },
@@ -20,7 +20,7 @@
       "name": "Debug Tests",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "test:debug"],
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "internalConsoleOptions": "neverOpen",
       "runtimeVersion": "20"
     },
@@ -30,7 +30,7 @@
       "name": "Debug Tests (Current File)",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "test:debug:nospec", "--", "--spec", "${relativeFile}"],
-      "console": "integratedTerminal",
+      "console": "internalConsole",
       "internalConsoleOptions": "neverOpen",
       "runtimeVersion": "20"
     }

--- a/README.md
+++ b/README.md
@@ -41,14 +41,16 @@ SLACK_ALERT_WEBHOOK_URI=Your Slack Incoming Webhook URI for error notifications 
 
 Next, if you're going to use the included strategies, you should configure them to your liking in the [./config](./config) directory. There are three files there:
 
-1. `basic_swap_accepter.json`: This is a list of pairs that the bot will accept swaps for. For each pair you can configure:
-   - `rate`: The rate that the bot will accept, compared to the market rate. For example, if GALA is currently trading at 4 cents and you configure trading GUSDC->GALA with a rate of `1.05`, the bot will accept swaps that offer at least 26.25 GALA per GUSDC. That is 5% better than the market rate (which would be 25 GALA per GUSDC).
-   - `giveLimitPerReset`: The maximum amount of the `givingTokenClass` you're willing to give per reset. This is useful if you want to limit how much trading the bot is allowed to do in a given time period.
-   - `resetIntervalMs`: The time period in milliseconds that the bot will wait before resetting the `giveLimitPerReset` counter. For example if this is set to `3600000` and `giveLimitPerReset` is set to `1000`, then this strategy won't spend more than `1000` of the `givingTokenClass` for accepting swaps over a one hour period.
-   - `maxPriceMovementPercent`: The maximum difference between the min and max price of either of the tokens in the pair during the number of milliseconds specified in the below option (`maxPriceMovementWindowMs`). If prices move more than this much during the specified period of time, the bot will stop accepting swaps for this pair until prices become less volatile. For example a value of `0.03` allows up to 3% price movement.
-   - `maxPriceMovementWindowMs`: The length of time in milliseconds that the bot will look back to calculate volatility as explained above.
-   - `maxReceivingTokenPriceUSD` (optional): If the price of the receiving token goes above this number of USD, the bot will stop accepting swaps for this pair.
-   - `minReceivingTokenAmount` (optional): The minimum amount of the receiving token that the bot will accept in a swap. If the bot cannot get at least this amount of the receiving token by accepting a swap, it will not accept the swap.
+1. `basic_swap_accepter.json`: This configures the conditions under which the bot will accept swaps. There are two subsections in here:
+   - `tradeLimits`: This is a list of pairs that the bot will accept swaps for. For each pair you can configure:
+     - `rate`: The rate that the bot will accept, compared to the market rate. For example, if GALA is currently trading at 4 cents and you configure trading GUSDC->GALA with a rate of `1.05`, the bot will accept swaps that offer at least 26.25 GALA per GUSDC. That is 5% better than the market rate (which would be 25 GALA per GUSDC).
+     - `giveLimitPerReset`: The maximum amount of the `givingTokenClass` you're willing to give per reset. This is useful if you want to limit how much trading the bot is allowed to do in a given time period.
+     - `resetIntervalMs`: The time period in milliseconds that the bot will wait before resetting the `giveLimitPerReset` counter. For example if this is set to `3600000` and `giveLimitPerReset` is set to `1000`, then this strategy won't spend more than `1000` of the `givingTokenClass` for accepting swaps over a one hour period.
+     - `maxPriceMovementPercent`: The maximum difference between the min and max price of either of the tokens in the pair during the number of milliseconds specified in the below option (`maxPriceMovementWindowMs`). If prices move more than this much during the specified period of time, the bot will stop accepting swaps for this pair until prices become less volatile. For example a value of `0.03` allows up to 3% price movement.
+     - `maxPriceMovementWindowMs`: The length of time in milliseconds that the bot will look back to calculate volatility as explained above.
+     - `maxReceivingTokenPriceUSD` (optional): If the price of the receiving token goes above this number of USD, the bot will stop accepting swaps for this pair.
+     - `minReceivingTokenAmount` (optional): The minimum amount of the receiving token that the bot will accept in a swap. If the bot cannot get at least this amount of the receiving token by accepting a swap, it will not accept the swap.
+   - `minimumBalances`: This is a list of minimum balances that the bot will maintain. The bot will not accept any swaps that would cause its balance to go below these minimums.
 2. `basic_swap_creator.json`: This defines swaps that the bot should create. There are three subsections in this configuration:
    - `targetActiveSwaps`: This is a list of pairs that the bot will try to keep active swaps for. For each pair you can configure:
      - `targetProfitability`: The rate that the bot will offer, compared to the market rate. For example, `1.05` means the bot will offer swaps that are 5% better (for itself) than the current market rate.

--- a/config/basic_swap_accepter.json
+++ b/config/basic_swap_accepter.json
@@ -39,5 +39,14 @@
       "maxPriceMovementPercent": 0.03,
       "maxPriceMovementWindowMs": 1800000
     }
+  ],
+  "minimumBalances": [
+    {
+      "collection": "GALA",
+      "category": "Unit",
+      "type": "none",
+      "additionalKey": "none",
+      "balance": 100
+    }
   ]
 }

--- a/src/strategies/basic_swap_accepter/basic_swap_accepter_strategy.ts
+++ b/src/strategies/basic_swap_accepter/basic_swap_accepter_strategy.ts
@@ -56,6 +56,7 @@ export class BasicSwapAccepterStrategy implements ISwapStrategy {
       this.config.tradeLimits,
       ownBalances,
       tokenValues,
+      this.config.minimumBalances,
       (givingTokenClass, receivingTokenClass) => {
         return galaSwapApi.getAvailableSwaps(givingTokenClass, receivingTokenClass);
       },

--- a/src/strategies/basic_swap_accepter/types.ts
+++ b/src/strategies/basic_swap_accepter/types.ts
@@ -16,6 +16,16 @@ export const accepterPairConfigSchema = z.object({
 
 export type IAccepterPairConfig = z.infer<typeof accepterPairConfigSchema>;
 
+export const minimumBalanceConfigSchema = z.object({
+  collection: z.string(),
+  category: z.string(),
+  type: z.string(),
+  additionalKey: z.string(),
+  minimumBalance: z.number().nonnegative(),
+});
+
+export type IMinimumBalanceConfig = z.infer<typeof minimumBalanceConfigSchema>;
+
 export const basicSwapAccepterConfigSchema = z.object({
   active: z.boolean(),
   tradeLimits: z.array(accepterPairConfigSchema).refine(
@@ -34,4 +44,5 @@ export const basicSwapAccepterConfigSchema = z.object({
     },
     { message: 'Trade limits must be unique per pair' },
   ),
+  minimumBalances: z.array(minimumBalanceConfigSchema),
 });

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -1,6 +1,9 @@
 import crypto from 'crypto';
 import { IGalaSwapToken, IRawSwap, ITokenBalance } from '../src/dependencies/galaswap/types.js';
-import { IAccepterPairConfig } from '../src/strategies/basic_swap_accepter/types.js';
+import {
+  IAccepterPairConfig,
+  IMinimumBalanceConfig,
+} from '../src/strategies/basic_swap_accepter/types.js';
 import { ITargetActiveSwaps } from '../src/strategies/basic_swap_creator/types.js';
 
 export function makeTokenClass(collection: string) {
@@ -104,5 +107,14 @@ export function makeTargetActiveSwap(options: Partial<ITargetActiveSwaps>): ITar
     maxPriceMovementPercent: 100,
     maxPriceMovementWindowMs: 1,
     ...options,
+  };
+}
+
+export function makeMinimumBalance(
+  options: { collection?: string | undefined; balance?: number } = {},
+): IMinimumBalanceConfig {
+  return {
+    ...makeTokenClass(options.collection ?? 'GUSDC'),
+    minimumBalance: options.balance ?? 0,
   };
 }


### PR DESCRIPTION
A new `minimumBalances` field in `config/basic_swap_accepter.json`. You can specify a minimum balance here, and the swap accepter strategy won't accept swaps that would bring your (useable) balance below that number.