### PR TITLE
Add givingTokenClassMinimumValue feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Next, if you're going to use the included strategies, you should configure them 
      - `maxPriceMovementPercent`: The maximum difference between the min and max price of either of the tokens in the pair during the number of milliseconds specified in the below option (`maxPriceMovementWindowMs`). If prices move more than this much during the specified period of time, the bot will stop creating swaps for this pair until prices become less volatile. For example a value of `0.03` allows up to 3% price movement.
      - `maxPriceMovementWindowMs`: The length of time in milliseconds that the bot will look back to calculate volatility as explained above.
      - `maxReceivingTokenPriceUSD` (optional): If the price of the receiving token goes above this number of USD, the bot will stop creating swaps for this pair.
+     - `givingTokenClassMinimumValue` (optional): If the giving token class's actual value (according to GalaSwap) goes below this number of USD, the bot will use the `givingTokenClassMinimumAmount` instead of the actual value. This allows you to set a lower limit on the rate that the bot will ask for.
    - `receivingTokenRoundingConfigs`: When the bot calculates how many tokens it wants to receive in a swap, it will round the number of tokens up to the number of `decimalPlaces` that you configure here.
    - `creationLimits`: The bot will stop creating new swaps when it gives a specified amount of the `givingTokenClass` within a specified time period. That's configurable here.
 3. `token_config.json`: This config file contains two sections:

--- a/src/strategies/basic_swap_creator/get_swap_to_create.ts
+++ b/src/strategies/basic_swap_creator/get_swap_to_create.ts
@@ -148,11 +148,23 @@ export async function getSwapsToCreate(
     }
 
     const amountToGive = BigNumber(target.targetGivingSize);
+    const minimumTokenValues =
+      typeof target.givingTokenClassMinimumValue === 'number'
+        ? [
+            {
+              ...target.givingTokenClass,
+              currentPrices: {
+                usd: target.givingTokenClassMinimumValue,
+              },
+            },
+          ]
+        : [];
 
     const currentMarketRate = getCurrentMarketRate(
       target.givingTokenClass,
       target.receivingTokenClass,
       tokenValues,
+      minimumTokenValues,
     );
 
     assert(currentMarketRate !== undefined, 'No current market rate found');

--- a/src/strategies/basic_swap_creator/get_swaps_to_terminate.ts
+++ b/src/strategies/basic_swap_creator/get_swaps_to_terminate.ts
@@ -45,10 +45,23 @@ export function getSwapsToTerminate(
       continue;
     }
 
+    const minimumTokenValues =
+      typeof target.givingTokenClassMinimumValue === 'number'
+        ? [
+            {
+              ...target.givingTokenClass,
+              currentPrices: {
+                usd: target.givingTokenClassMinimumValue,
+              },
+            },
+          ]
+        : [];
+
     const currentMarketRate = getCurrentMarketRate(
       swapOffered.tokenInstance,
       swapWanted.tokenInstance,
       tokenValues,
+      minimumTokenValues,
     );
 
     assert(currentMarketRate !== undefined, 'No current market rate found');

--- a/src/strategies/basic_swap_creator/types.ts
+++ b/src/strategies/basic_swap_creator/types.ts
@@ -22,6 +22,7 @@ const targetActiveSwapsSchema = z
     maxPriceMovementPercent: z.number().positive(),
     maxPriceMovementWindowMs: z.number().positive(),
     maxReceivingTokenPriceUSD: z.number().positive().optional(),
+    givingTokenClassMinimumValue: z.number().positive().optional(),
   })
   .refine((data) => data.minProfitability < data.maxProfitability, {
     message: 'minProfitability must be less than maxProfitability',

--- a/test/galaswap_api_tests.spec.ts
+++ b/test/galaswap_api_tests.spec.ts
@@ -1,12 +1,13 @@
 import assert from 'assert';
+import { Wallet } from 'ethers';
 import { GalaSwapApi, GalaSwapErrorResponse } from '../src/dependencies/galaswap/galaswap_api.js';
 import { mockLogger } from './mocks/noop_proxy.js';
 
 describe('GalaSwap API tests', () => {
   const unauthenticatedApi = new GalaSwapApi(
     'https://api-galaswap.gala.com',
-    'client|abcde',
-    '0x0000000000000000000000000000000000000000000000000000000000000001',
+    'client|abceabcdabcdabfdabceabcd',
+    Wallet.createRandom().privateKey,
     fetch,
     mockLogger,
     { maxRetries: 0 },
@@ -51,7 +52,7 @@ describe('GalaSwap API tests', () => {
         'Expected error to be instance of GalaSwapErrorResponse',
       );
 
-      assert.equal(err.errorCode, 'PK_NOT_FOUND');
+      assert.equal(err.errorCode, 'PUBLIC_KEY_MISMATCH');
     }
   }).timeout(10_000);
 });

--- a/test/strategy_tests/basic_swap_creator_stateless.spec.ts
+++ b/test/strategy_tests/basic_swap_creator_stateless.spec.ts
@@ -2,10 +2,12 @@ import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import { IRawSwap } from '../../src/dependencies/galaswap/types.js';
 import { getSwapsToCreate } from '../../src/strategies/basic_swap_creator/get_swap_to_create.js';
+import { getSwapsToTerminate } from '../../src/strategies/basic_swap_creator/get_swaps_to_terminate.js';
 import { mainLoopTick } from '../../src/tick_loop.js';
 import { MockGalaSwapApi } from '../mocks/mock_gala_swap_api.js';
 import { mockLogger, mockReporter, noopProxy } from '../mocks/noop_proxy.js';
 import {
+  createTestSwap,
   makeBalance,
   makeTargetActiveSwap,
   makeTokenClass,
@@ -319,5 +321,98 @@ describe('Basic swap creator tests', () => {
     );
 
     assert.equal(swapTosCreate2.length, 0);
+  });
+
+  it('Respects givingTokenClassMinimumValue', async () => {
+    const createdSwaps: IRawSwap[] = [];
+    const targets = [
+      makeTargetActiveSwap({
+        givingTokenClass: makeTokenClass('GUSDC'),
+        receivingTokenClass: makeTokenClass('GALA'),
+        targetProfitability: 1.1,
+        minProfitability: 1,
+        maxProfitability: 2,
+        targetGivingSize: 1000,
+        givingTokenClassMinimumValue: 10,
+      }),
+    ];
+
+    const ownBalances = [
+      makeBalance({ collection: 'GUSDC', quantity: '1000' }),
+      makeBalance({ collection: 'GALA', quantity: '1' }),
+    ];
+
+    const tokenValues = [
+      makeTokenValue({ collection: 'GALA', usd: 0.05 }),
+      makeTokenValue({ collection: 'GUSDC', usd: 1 }),
+    ];
+
+    const swapsToCreate1 = await getSwapsToCreate(
+      mockReporter,
+      mockLogger,
+      ownBalances,
+      createdSwaps,
+      tokenValues,
+      {
+        ...defaultTestSwapCreatorConfig,
+        targetActiveSwaps: targets,
+      },
+      zeroQuantityCreatedSince,
+      undefinedPriceChangePercent,
+    );
+
+    // Make sure it created a swap using the minimum value specified for GUSDC (10) rather than the actual value (1)
+    const swapToCreate1 = swapsToCreate1[0];
+    assert(swapToCreate1);
+    assert.equal(swapToCreate1.offered[0].tokenInstance.collection, 'GUSDC');
+    assert.equal(swapToCreate1.wanted[0].tokenInstance.collection, 'GALA');
+    const uses = BigNumber(swapToCreate1.uses);
+    assert.equal(BigNumber(swapToCreate1.offered[0].quantity).multipliedBy(uses), '1000');
+    assert.equal(BigNumber(swapToCreate1.wanted[0].quantity).multipliedBy(uses), '220000'); // 10 * 1000 / 0.05 * 1.1
+
+    // Make sure it doesn't terminate that swap right after creation
+    const swapsToTerminate1 = await getSwapsToTerminate(
+      [createTestSwap(swapToCreate1)],
+      tokenValues,
+      targets,
+    );
+    assert.equal(swapsToTerminate1.length, 0);
+
+    const tokenValues2 = [
+      makeTokenValue({ collection: 'GALA', usd: 0.05 }),
+      makeTokenValue({ collection: 'GUSDC', usd: 15 }), // Increase the actual value of GUSDC to 15
+    ];
+
+    // Make sure it terminates the swap now that the actual value of GUSDC is so much higher
+    const swapsToTerminate2 = await getSwapsToTerminate(
+      [createTestSwap(swapToCreate1)],
+      tokenValues2,
+      targets,
+    );
+
+    assert.equal(swapsToTerminate2.length, 1);
+
+    const swapsToCreate2 = await getSwapsToCreate(
+      mockReporter,
+      mockLogger,
+      ownBalances,
+      [],
+      tokenValues2,
+      {
+        ...defaultTestSwapCreatorConfig,
+        targetActiveSwaps: targets,
+      },
+      zeroQuantityCreatedSince,
+      undefinedPriceChangePercent,
+    );
+
+    // Make sure that when the actual value of GUSDC is higher than the min, it uses the actual value
+    assert.equal(swapsToCreate2.length, 1);
+    const swapToCreate2 = swapsToCreate2[0];
+    assert(swapToCreate2);
+    assert.equal(swapToCreate2.offered[0].tokenInstance.collection, 'GUSDC');
+    assert.equal(swapToCreate2.wanted[0].tokenInstance.collection, 'GALA');
+    assert.equal(BigNumber(swapToCreate2.offered[0].quantity).multipliedBy(uses), '1000');
+    assert.equal(BigNumber(swapToCreate2.wanted[0].quantity).multipliedBy(uses), '330000'); // 15 * 1000 / 0.05 * 1.1
   });
 });

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -118,3 +118,16 @@ export function makeMinimumBalance(
     minimumBalance: options.balance ?? 0,
   };
 }
+
+export function createTestSwap(
+  swapToCreate: Pick<IRawSwap, 'offered' | 'wanted' | 'uses'>,
+): IRawSwap {
+  return {
+    ...swapToCreate,
+    swapRequestId: crypto.randomUUID(),
+    created: Date.now(),
+    expires: 0,
+    usesSpent: '0',
+    offeredBy: 'client',
+  };
+}


### PR DESCRIPTION
A new configuration option for target active swaps in the basic_swap_creator strategy:

> If the giving token class's actual value (according to GalaSwap) goes below this number of USD, the bot will use the `givingTokenClassMinimumAmount` instead of the actual value. This allows you to set a lower limit on the rate that the bot will ask for.